### PR TITLE
Bug #17: Breakpoints in included files are ignored

### DIFF
--- a/CoreSpectrum/Hardware/SpectrumBase.cs
+++ b/CoreSpectrum/Hardware/SpectrumBase.cs
@@ -363,7 +363,6 @@ namespace CoreSpectrum.Hardware
         protected virtual void z80_BeforeInstructionFetch(object? sender, Konamiman.Z80dotNet.BeforeInstructionFetchEventArgs e)
         {
             var bp = _breakpoints[_z80.Registers.PC];
-
             if (bp == null)
                 return;
 

--- a/ZXBStudio/BuildSystem/ZXCodeFile.cs
+++ b/ZXBStudio/BuildSystem/ZXCodeFile.cs
@@ -100,7 +100,7 @@ namespace ZXBasicStudio.BuildSystem
             return $"file__{FileGuid}__{lineNum}:\n{line}";
         }
 
-        public void CreateBuildFile(IEnumerable<ZXCodeFile> AllFiles)
+        public void CreateBuildFile(IEnumerable<ZXCodeFile> AllFiles, TextWriter textWriter)
         {
             string content = Content;
             string[] lines = content.Replace("\r", "").Split("\n");
@@ -238,7 +238,7 @@ namespace ZXBasicStudio.BuildSystem
                             var file = regInclude.Match(line).Groups[1].Value;
                             var absoluteFile = Path.GetFullPath(Path.Combine(Directory, file));
 
-                            var codeFile = AllFiles.FirstOrDefault(f => f.AbsolutePath == absoluteFile);
+                            var codeFile = AllFiles.FirstOrDefault(f => f.AbsolutePath.ToLower() == absoluteFile.ToLower());
 
                             if (codeFile != null)
                                 line = line.Replace(file, Path.Combine(codeFile.Directory, codeFile.TempFileName));
@@ -279,8 +279,8 @@ namespace ZXBasicStudio.BuildSystem
                     }
                     else
                         dotrim = false;
-                }
-
+                }                
+                textWriter.WriteLine($"Crating temp file: {TempFileName}");
                 File.WriteAllText(Path.Combine(Directory, TempFileName), sb.ToString());
             }
         }

--- a/ZXBStudio/Dialogs/ZXAboutDialog.axaml.cs
+++ b/ZXBStudio/Dialogs/ZXAboutDialog.axaml.cs
@@ -12,8 +12,8 @@ public partial class ZXAboutDialog : Window
     {
         InitializeComponent();
 
-        txtBuild.Text = "1.6.0-beta1";
-        txtDate.Text = "2025-04-26";
+        txtBuild.Text = "1.6.0-beta2";
+        txtDate.Text = "2025-05-02";
 
         btnClose.Click += BtnClose_Click;
 


### PR DESCRIPTION
The bug occurs when the name specified in an #include does not exactly match the file due to case sensitive issues.