### PR TITLE
Features/advanced project options

### DIFF
--- a/ZXBStudio/App.axaml
+++ b/ZXBStudio/App.axaml
@@ -180,12 +180,21 @@
       <Setter Property="Height" Value="32"></Setter>
       <Setter Property="MaxWidth" Value="140"></Setter>
     </Style>
+    <Style Selector="TextBox.dialogfw">
+      <Setter Property="Margin" Value="5"></Setter>
+      <Setter Property="CornerRadius" Value="5"></Setter>
+      <Setter Property="Height" Value="32"></Setter>
+    </Style>
+    <Style Selector="TextBox.dialogfwh">
+      <Setter Property="Margin" Value="5"></Setter>
+      <Setter Property="CornerRadius" Value="5"></Setter>
+    </Style>
     <Style Selector="Button.dialog">
       <Setter Property="Margin" Value="5"></Setter>
       <Setter Property="CornerRadius" Value="5"></Setter>
     </Style>
     <Style Selector="ComboBox.dialog">
-      <Setter Property="Margin" Value="0"></Setter>
+      <Setter Property="Margin" Value="5"></Setter>
       <Setter Property="CornerRadius" Value="5"></Setter>
       <Setter Property="Height" Value="32"></Setter>
       <Setter Property="Padding" Value="5"></Setter>

--- a/ZXBStudio/BuildSystem/ZXProjectBuilder.cs
+++ b/ZXBStudio/BuildSystem/ZXProjectBuilder.cs
@@ -753,7 +753,7 @@ namespace ZXBasicStudio.BuildSystem
         }
 
 
-        private static bool ExecuteFile(string preBuildValue, string[] parameters, string workingPath, TextWriter outLog)
+        public static bool ExecuteFile(string preBuildValue, string[] parameters, string workingPath, TextWriter outLog)
         {
             try
             {

--- a/ZXBStudio/BuildSystem/ZXProjectBuilder.cs
+++ b/ZXBStudio/BuildSystem/ZXProjectBuilder.cs
@@ -8,8 +8,10 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using ZXBasicStudio.Classes;
+using ZXBasicStudio.Controls;
 using ZXBasicStudio.Dialogs;
 using ZXBasicStudio.DocumentModel.Classes;
 using ZXBasicStudio.IntegratedDocumentTypes.CodeDocuments.Basic;
@@ -51,6 +53,22 @@ namespace ZXBasicStudio.BuildSystem
                 settings = project.GetProjectSettings();
                 mainFile = project.GetMainFile();
 
+                // Prebuild
+                if (settings.PreBuild)
+                {
+                    OutputLogWritter.WriteLine($"PreBuild: {settings.PreBuildValue}");
+                    if (!ExecuteFile(settings.PreBuildValue, new string[]
+                        {
+                            project.ProjectPath,
+                            Path.GetFileName(mainFile)
+                        },
+                        project.ProjectPath,
+                        OutputLogWritter))
+                    {
+                        return null;
+                    }
+                }
+
                 if (mainFile == null)
                 {
                     OutputLogWritter.WriteLine("Cannot find main file, check that it exists and if there are more than one that is specified in the build settings.");
@@ -60,14 +78,19 @@ namespace ZXBasicStudio.BuildSystem
                 if (!PreBuild(false, project.ProjectPath, OutputLogWritter))
                     return null;
 
-                var args = settings.GetSettings();
-
+                Process? proc = null;
                 var startTime = DateTime.Now;
                 OutputLogWritter.WriteLine("Project path: " + project.ProjectPath);
                 OutputLogWritter.WriteLine("Building program " + mainFile);
                 OutputLogWritter.WriteLine("Building starts at " + startTime);
-
-                var proc = Process.Start(new ProcessStartInfo(Path.GetFullPath(ZXOptions.Current.ZxbcPath), $"\"{mainFile}\" " + args) { WorkingDirectory = project.ProjectPath, RedirectStandardError = true, CreateNoWindow = true });
+                var args = settings.GetSettings();
+                if (settings.CustomCompiler)
+                {
+                    OutputLogWritter.WriteLine("Custom compiler settings");
+                    args = settings.CustomCompilerValue;
+                }
+                OutputLogWritter.WriteLine($"zxbc \"{mainFile}\" {args}");
+                proc = Process.Start(new ProcessStartInfo(Path.GetFullPath(ZXOptions.Current.ZxbcPath), $"\"{mainFile}\" " + args) { WorkingDirectory = project.ProjectPath, RedirectStandardError = true, CreateNoWindow = true });
 
                 string logOutput;
 
@@ -83,6 +106,22 @@ namespace ZXBasicStudio.BuildSystem
                 }
 
                 string binFile = Path.Combine(project.ProjectPath, Path.GetFileNameWithoutExtension(mainFile) + ".bin");
+
+                // Postbuild
+                if (settings.PostBuild)
+                {
+                    OutputLogWritter.WriteLine($"PostBuild: {settings.PostBuildValue}");
+                    if (!ExecuteFile(settings.PostBuildValue, new string[]
+                        {
+                            project.ProjectPath,
+                            Path.GetFileName(binFile)
+                        },
+                        project.ProjectPath,
+                        OutputLogWritter))
+                    {
+                        return null;
+                    }
+                }
 
                 byte[] binary = File.ReadAllBytes(binFile);
 
@@ -309,6 +348,22 @@ namespace ZXBasicStudio.BuildSystem
                 settings = project.GetProjectSettings();
                 mainFile = project.GetMainFile();
 
+                // Prebuild
+                if (settings.PreBuild)
+                {
+                    OutputLogWritter.WriteLine($"PreBuild: {settings.PreBuildValue}");
+                    if (!ExecuteFile(settings.PreBuildValue, new string[]
+                        {
+                            project.ProjectPath,
+                            Path.GetFileName(mainFile)
+                        },
+                        project.ProjectPath,
+                        OutputLogWritter))
+                    {
+                        return null;
+                    }
+                }
+
                 if (mainFile == null)
                 {
                     OutputLogWritter.WriteLine("Cannot find main file, check that it exists and if there are more than one that is specified in the build settings.");
@@ -329,6 +384,11 @@ namespace ZXBasicStudio.BuildSystem
                 string logOutput;
 
                 var args = settings.GetDebugSettings();
+                if (settings.CustomCompiler)
+                {
+                    OutputLogWritter.WriteLine("Custom compiler settings");
+                    args = settings.CustomCompilerValue;
+                }
 
                 OutputLogWritter.WriteLine("Building map files...");
 
@@ -339,7 +399,6 @@ namespace ZXBasicStudio.BuildSystem
 
                 OutputLogWritter.WriteLine("Building program map...");
 
-                // TODO: DUEFECTU 2023.05.17: Bug for long path
                 var codeFile = files.FirstOrDefault(f => f.AbsolutePath == Path.GetFullPath(mainFile));
                 if (codeFile == null)
                 {
@@ -349,10 +408,10 @@ namespace ZXBasicStudio.BuildSystem
                 }
 
                 cmd = $"\"{Path.Combine(codeFile.Directory, codeFile.TempFileName)}\" -M MEMORY_MAP " + args;
-                OutputLogWritter.WriteLine("zxbc "+cmd);
+                OutputLogWritter.WriteLine("zxbc " + cmd);
                 var proc = Process.Start(
                     new ProcessStartInfo(
-                        Path.GetFullPath(ZXOptions.Current.ZxbcPath),cmd)
+                        Path.GetFullPath(ZXOptions.Current.ZxbcPath), cmd)
                     { WorkingDirectory = project.ProjectPath, RedirectStandardError = true, CreateNoWindow = true });
 
                 OutputProcessLog(OutputLogWritter, proc, out logOutput);
@@ -691,6 +750,74 @@ namespace ZXBasicStudio.BuildSystem
             }
 
             return true;
+        }
+
+
+        private static bool ExecuteFile(string preBuildValue, string[] parameters, string workingPath, TextWriter outLog)
+        {
+            try
+            {
+                var proc = Process.Start(
+                    new ProcessStartInfo(
+                        preBuildValue,
+                        parameters)
+                    {
+                        WorkingDirectory = workingPath,
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        CreateNoWindow = true
+                    });
+
+                string logOutput = "";
+                ProcessRedirect(proc, outLog);
+
+                var ecode = proc.ExitCode;
+
+                if (ecode != 0)
+                {
+                    Cleanup(workingPath);
+                    outLog.WriteLine("Error building program, aborting...");
+                    return false;
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                outLog.WriteLine("ERROR executing file: " + ex.Message);
+                return false;
+            }
+        }
+
+
+        private static void ProcessRedirect(Process proc, TextWriter outLog)
+        {
+            try
+            {
+                while (!proc.HasExited)
+                {
+                    if (!proc.StandardOutput.EndOfStream)
+                    {
+                        string? line = proc.StandardOutput.ReadLine();
+                        outLog.WriteLine(line);
+                    }
+                    if (!proc.StandardError.EndOfStream)
+                    {
+                        string? line = proc.StandardError.ReadLine();
+                        outLog.WriteLine(line);
+                    }
+                }
+                while (!proc.StandardOutput.EndOfStream)
+                {
+                    string? line = proc.StandardOutput.ReadLine();
+                    outLog.WriteLine(line);
+                }
+                while (!proc.StandardError.EndOfStream)
+                {
+                    string? line = proc.StandardError.ReadLine();
+                    outLog.WriteLine(line);
+                }
+            }
+            catch { }
         }
     }
 }

--- a/ZXBStudio/Classes/ZXBuildSettings.cs
+++ b/ZXBStudio/Classes/ZXBuildSettings.cs
@@ -24,6 +24,17 @@ namespace ZXBasicStudio.Classes
         public bool Strict { get; set; }
         public bool Headerless { get; set; }
         public bool NextMode { get; set; }
+
+        public bool PreBuild { get; set; }
+        public string PreBuildValue { get; set; }
+        public bool CustomCompiler { get; set; }
+        public string CustomCompilerValue { get; set; }
+        public bool PostBuild { get; set; }
+        public string PostBuildValue { get; set; }
+        public bool ExternalEmulator { get; set; }
+        public string ExternalEmuladorValue { get; set; }
+
+
         public string GetSettings()
         {
             List<string> settings = new List<string>();
@@ -68,6 +79,11 @@ namespace ZXBasicStudio.Classes
 
             if (Strict)
                 settings.Add("--strict");
+
+            if (Headerless)
+            {
+                settings.Add("--headerless");
+            }
 
             if (NextMode)
             {

--- a/ZXBStudio/Classes/ZXLogTextWriter.cs
+++ b/ZXBStudio/Classes/ZXLogTextWriter.cs
@@ -14,10 +14,12 @@ namespace ZXBasicStudio.Classes
 {
     public class ZXLogTextWriter : TextWriter
     {
-        TextBlock target;
+        //TextBlock target;
+        TextBox target;
         ScrollViewer scroll;
 
-        public ZXLogTextWriter(TextBlock Target, ScrollViewer Scroller) 
+        //public ZXLogTextWriter(TextBlock Target, ScrollViewer Scroller) 
+        public ZXLogTextWriter(TextBox Target, ScrollViewer Scroller)
         {
             this.target = Target;
             this.scroll = Scroller;

--- a/ZXBStudio/Controls/ZXOutputLog.axaml
+++ b/ZXBStudio/Controls/ZXOutputLog.axaml
@@ -5,24 +5,31 @@
              xmlns:svg="using:Avalonia.Svg.Skia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ZXBasicStudio.Controls.ZXOutputLog">
-    <UserControl.ContextMenu>
-        <ContextMenu Placement="Pointer">
-            <MenuItem Header="Clear output window" Name="mnuClearOutputWindow" />
-            <MenuItem Header="Copy to clipboard" Name="mnuCopyToClipboard" />
-        </ContextMenu>
-    </UserControl.ContextMenu>
-    <Grid RowDefinitions="auto,*">
-        <Grid ColumnDefinitions="1*" DataContext=".ZXMemoryView">
-            <StackPanel Grid.Row="0" Spacing="2" Orientation="Horizontal" Margin="2" HorizontalAlignment="Left">
-                <Button Width="30" Foreground="Black" Classes="toolbar" Name="btnClearOutputWindow" ToolTip.Tip="Clear output window"><svg:Svg Path="/Svg/eraser-solid.svg"></svg:Svg></Button>
-                <Button Width="30" Foreground="Black" Classes="toolbar" Name="btnCopyToClipboard" ToolTip.Tip="Copy output log to clipboard"><svg:Svg Path="/Svg/copy-solid.svg"></svg:Svg></Button>
-            </StackPanel>
-        </Grid>
-        <Grid Grid.Row="1">
-        <ScrollViewer HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="#FF202020" Name="scrOutput"
-                      VerticalScrollBarVisibility="Auto">
-            <TextBlock TextWrapping="Wrap" Foreground="White" Name="tbOutput" Padding="10"></TextBlock>
-        </ScrollViewer>
-        </Grid>
+  <UserControl.ContextMenu>
+    <ContextMenu Placement="Pointer">
+      <MenuItem Header="Clear output window" Name="mnuClearOutputWindow" />
+      <MenuItem Header="Copy to clipboard" Name="mnuCopyToClipboard" />
+    </ContextMenu>
+  </UserControl.ContextMenu>
+  <Grid RowDefinitions="auto,*">
+    <Grid ColumnDefinitions="1*" DataContext=".ZXMemoryView">
+      <StackPanel Grid.Row="0" Spacing="2" Orientation="Horizontal" Margin="2" HorizontalAlignment="Left">
+        <Button Width="30" Foreground="Black" Classes="toolbar" Name="btnClearOutputWindow" ToolTip.Tip="Clear output window">
+          <svg:Svg Path="/Svg/eraser-solid.svg"></svg:Svg>
+        </Button>
+        <Button Width="30" Foreground="Black" Classes="toolbar" Name="btnCopyToClipboard" ToolTip.Tip="Copy output log to clipboard">
+          <svg:Svg Path="/Svg/copy-solid.svg"></svg:Svg>
+        </Button>
+      </StackPanel>
     </Grid>
+    <Grid Grid.Row="1">
+      <ScrollViewer HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="#FF202020" Name="scrOutput"
+                    VerticalScrollBarVisibility="Auto">
+        <!--
+        <TextBlock TextWrapping="Wrap" Foreground="White" Name="tbOutput" Padding="10" IsVisible="False"/>
+        -->
+        <TextBox TextWrapping="Wrap" AcceptsReturn="True" Foreground="White" Name="tbOutput" Padding="10" IsReadOnly="True"/>
+      </ScrollViewer>
+    </Grid>
+  </Grid>
 </UserControl>

--- a/ZXBStudio/Dialogs/ZXAboutDialog.axaml.cs
+++ b/ZXBStudio/Dialogs/ZXAboutDialog.axaml.cs
@@ -12,8 +12,8 @@ public partial class ZXAboutDialog : Window
     {
         InitializeComponent();
 
-        txtBuild.Text = "1.6.0-beta3";
-        txtDate.Text = "2025-05-13";
+        txtBuild.Text = "1.6.0-beta4";
+        txtDate.Text = "2025-05-21";
 
         btnClose.Click += BtnClose_Click;
 

--- a/ZXBStudio/Dialogs/ZXBuildSettingsDialog.axaml
+++ b/ZXBStudio/Dialogs/ZXBuildSettingsDialog.axaml
@@ -3,68 +3,109 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:wnd="using:ZXBasicStudio.Classes"
-        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="520"
-        MinWidth="400" Width="400"
-        MinHeight="450" Height="450" 
+        xmlns:svg="using:Avalonia.Svg.Skia"
+        mc:Ignorable="d" d:DesignWidth="820" d:DesignHeight="430"
+        Width="820" Height="430"
         CanResize="False"
         Icon="/Assets/zxbs.ico"
         x:Class="ZXBasicStudio.Dialogs.ZXBuildSettingsDialog"
         Title="Build settings" WindowStartupLocation="CenterOwner">
-  <Grid ColumnDefinitions="*,5*,12*,*,*,6*,2*,2*" RowDefinitions="*,*,*,*,*,*,*,*,1.5*">
-    <TextBlock Classes="dialog" Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Main file:</TextBlock>
-    <TextBox Classes="dialog" Grid.Row="0" Grid.Column="2" Name="txtFile"></TextBox>
-    <TextBlock Classes="dialog" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Optimization:</TextBlock>
-    <ComboBox Classes="dialog" Grid.Row="1" Grid.Column="2" Name="cbOptimization">
-      <ComboBoxItem>0</ComboBoxItem>
-      <ComboBoxItem>1</ComboBoxItem>
-      <ComboBoxItem>2</ComboBoxItem>
-      <ComboBoxItem>3</ComboBoxItem>
-      <ComboBoxItem>4</ComboBoxItem>
-      <ComboBoxItem>5</ComboBoxItem>
-      <ComboBoxItem>6</ComboBoxItem>
-      <ComboBoxItem>7</ComboBoxItem>
-    </ComboBox>
-    <TextBlock Classes="dialog" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Origin:</TextBlock>
-    <Border Height="32" Grid.Row="2" Grid.Column="2" BorderBrush="#ff909090" BorderThickness="2" CornerRadius="5" Padding="-1" Margin="5,0,5,0">
-      <NumericUpDown Classes="dialog" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ParsingNumberStyle="Integer" Value="32768" FormatString="####" Minimum="0" Maximum="65535" Name="nudOrg"></NumericUpDown>
-    </Border>
-    <TextBlock Classes="dialog" Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Array base:</TextBlock>
-    <ComboBox Classes="dialog" Grid.Row="3" Grid.Column="2" Name="cbArrayBase">
-      <ComboBoxItem>0</ComboBoxItem>
-      <ComboBoxItem>1</ComboBoxItem>
-    </ComboBox>
-    <TextBlock Classes="dialog" Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">String base:</TextBlock>
-    <ComboBox Classes="dialog" Grid.Row="4" Grid.Column="2"  Name="cbStringBase">
-      <ComboBoxItem>0</ComboBoxItem>
-      <ComboBoxItem>1</ComboBoxItem>
-    </ComboBox>
-    <TextBlock Classes="dialog" Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Heap size:</TextBlock>
-    <Border Grid.Row="5" Grid.Column="2" Classes="numericborder">
-      <NumericUpDown Classes="dialog" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ParsingNumberStyle="Integer" Value="4768" FormatString="####" Minimum="0" Maximum="32768" Name="nudHeap"></NumericUpDown>
-    </Border>
-    <TextBlock Classes="dialog" Grid.Row="6" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Defines:</TextBlock>
-    <TextBox Classes="dialog" Grid.Row="6" Grid.Column="2" Name="txtDefines"></TextBox>
-    
-    <TextBlock Classes="dialog" Grid.Row="0" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Sinclair mode:</TextBlock>
-    <CheckBox Classes="dialog" Grid.Row="0" Grid.Column="6"  Name="ckSinclair"></CheckBox>
-    <TextBlock Classes="dialog" Grid.Row="1" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Strict bool:</TextBlock>
-    <CheckBox Grid.Row="1" Grid.Column="6"  Name="ckStrictBool"></CheckBox>
-    <TextBlock Classes="dialog" Grid.Row="2" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Enable break:</TextBlock>
-    <CheckBox Grid.Row="2" Grid.Column="6"  Name="ckBreak"></CheckBox>
-    <TextBlock Classes="dialog" Grid.Row="3" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Explicit:</TextBlock>
-    <CheckBox Grid.Row="3" Grid.Column="6"  Name="ckExplicit"></CheckBox>
-    <TextBlock Classes="dialog" Grid.Row="4" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Ignore case:</TextBlock>
-    <CheckBox Grid.Row="4" Grid.Column="6"  Name="ckCase"></CheckBox>
-    <TextBlock Classes="dialog" Grid.Row="5" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Strict:</TextBlock>
-    <CheckBox Grid.Row="5" Grid.Column="6"  Name="ckStrict"></CheckBox>
-    <TextBlock Classes="dialog" Grid.Row="6" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Headerless:</TextBlock>
-    <CheckBox Grid.Row="6" Grid.Column="6"  Name="ckHeaderless"></CheckBox>
-    <TextBlock Classes="dialog" Grid.Row="7" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Next mode:</TextBlock>
-    <CheckBox Grid.Row="7" Grid.Column="6"  Name="ckNext"></CheckBox>
-    
-    <StackPanel Margin="10,15,10,15" Grid.Row="8" Grid.ColumnSpan="8" Orientation="Horizontal" HorizontalAlignment="Right">
+  <Grid ColumnDefinitions="400,16,400" RowDefinitions="*,16,Auto">
+    <Grid ColumnDefinitions="*,5*,12*,*,*,6*,2*,2*" RowDefinitions="*,*,*,*,*,*,*,*,1.5*">
+      <TextBlock Classes="dialog" Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Main file:</TextBlock>
+      <TextBox Classes="dialog" Grid.Row="0" Grid.Column="2" Name="txtFile"></TextBox>
+      <TextBlock Classes="dialog" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Optimization:</TextBlock>
+      <ComboBox Classes="dialog" Grid.Row="1" Grid.Column="2" Name="cbOptimization">
+        <ComboBoxItem>0</ComboBoxItem>
+        <ComboBoxItem>1</ComboBoxItem>
+        <ComboBoxItem>2</ComboBoxItem>
+        <ComboBoxItem>3</ComboBoxItem>
+        <ComboBoxItem>4</ComboBoxItem>
+        <ComboBoxItem>5</ComboBoxItem>
+        <ComboBoxItem>6</ComboBoxItem>
+        <ComboBoxItem>7</ComboBoxItem>
+      </ComboBox>
+      <TextBlock Classes="dialog" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Origin:</TextBlock>
+      <Border Height="32" Grid.Row="2" Grid.Column="2" BorderBrush="#ff909090" BorderThickness="2" CornerRadius="5" Padding="-1" Margin="5,0,5,0">
+        <NumericUpDown Classes="dialog" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ParsingNumberStyle="Integer" Value="32768" FormatString="####" Minimum="0" Maximum="65535" Name="nudOrg"></NumericUpDown>
+      </Border>
+      <TextBlock Classes="dialog" Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Array base:</TextBlock>
+      <ComboBox Classes="dialog" Grid.Row="3" Grid.Column="2" Name="cbArrayBase">
+        <ComboBoxItem>0</ComboBoxItem>
+        <ComboBoxItem>1</ComboBoxItem>
+      </ComboBox>
+      <TextBlock Classes="dialog" Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">String base:</TextBlock>
+      <ComboBox Classes="dialog" Grid.Row="4" Grid.Column="2"  Name="cbStringBase">
+        <ComboBoxItem>0</ComboBoxItem>
+        <ComboBoxItem>1</ComboBoxItem>
+      </ComboBox>
+      <TextBlock Classes="dialog" Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Heap size:</TextBlock>
+      <Border Grid.Row="5" Grid.Column="2" Classes="numericborder">
+        <NumericUpDown Classes="dialog" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ParsingNumberStyle="Integer" Value="4768" FormatString="####" Minimum="0" Maximum="32768" Name="nudHeap"></NumericUpDown>
+      </Border>
+      <TextBlock Classes="dialog" Grid.Row="6" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Right">Defines:</TextBlock>
+      <TextBox Classes="dialog" Grid.Row="6" Grid.Column="2" Name="txtDefines"></TextBox>
+
+      <TextBlock Classes="dialog" Grid.Row="0" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Sinclair mode:</TextBlock>
+      <CheckBox Classes="dialog" Grid.Row="0" Grid.Column="6"  Name="ckSinclair"></CheckBox>
+
+      <!--
+      <TextBlock Classes="dialog" Grid.Row="1" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Strict bool:</TextBlock>
+      <CheckBox Grid.Row="1" Grid.Column="6"  Name="ckStrictBool"></CheckBox>
+      -->
+      <TextBlock Classes="dialog" Grid.Row="1" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Enable break:</TextBlock>
+      <CheckBox Grid.Row="1" Grid.Column="6"  Name="ckBreak"></CheckBox>
+      <TextBlock Classes="dialog" Grid.Row="2" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Explicit:</TextBlock>
+      <CheckBox Grid.Row="2" Grid.Column="6"  Name="ckExplicit"></CheckBox>
+      <TextBlock Classes="dialog" Grid.Row="3" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Ignore case:</TextBlock>
+      <CheckBox Grid.Row="3" Grid.Column="6"  Name="ckCase"></CheckBox>
+      <TextBlock Classes="dialog" Grid.Row="4" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Strict:</TextBlock>
+      <CheckBox Grid.Row="4" Grid.Column="6"  Name="ckStrict"></CheckBox>
+      <TextBlock Classes="dialog" Grid.Row="5" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Headerless:</TextBlock>
+      <CheckBox Grid.Row="5" Grid.Column="6"  Name="ckHeaderless"></CheckBox>
+      <TextBlock Classes="dialog" Grid.Row="6" Grid.Column="5" VerticalAlignment="Center" HorizontalAlignment="Right">Next mode:</TextBlock>
+      <CheckBox Grid.Row="6" Grid.Column="6"  Name="ckNext"></CheckBox>
+    </Grid>
+
+    <Grid Grid.Column="2">
+      <StackPanel Orientation="Vertical">
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+          <CheckBox Name="chkPrebuild" Grid.Row="5" Grid.Column="6"  Margin="0,12,4,0">Enable pre-build (program or bash to launch)</CheckBox>
+          <svg:Svg Path="/Svg/White/circle-info-solid.svg" Width="16" ToolTip.Tip="Parameters: %1=project path, %2=main file .bas"></svg:Svg>
+        </StackPanel>
+        <Grid Name="grdPrebuild" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" IsEnabled="False" Margin="20,4,8,8">
+          <TextBox  Name="txtPreBuild" Grid.Row="1" Classes="dialogfw"/>
+          <Button Classes="dialog" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Name="btnPrebuild">...</Button>
+        </Grid>
+
+        <CheckBox Name="chkCompiler" Grid.Row="5" Grid.Column="6"  Margin="0,8,0,0">Custom compiler parameters</CheckBox>
+        <Grid Name="grdCompiler" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" IsEnabled="False" Margin="20,4,8,8">
+          <TextBox  Name="txtCompiler" Grid.Row="1" Classes="dialogfwh" Height="64" AcceptsReturn="True" TextWrapping="Wrap"/>
+        </Grid>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+          <CheckBox Name="chkPostbuild" Grid.Row="5" Grid.Column="6"  Margin="0,8,4,0">Enable post-build (program or bash to launch)</CheckBox>
+          <svg:Svg Path="/Svg/White/circle-info-solid.svg" Width="16" ToolTip.Tip="Parameters: %1=project path, %2=compiled file .bin"></svg:Svg>
+        </StackPanel>
+        <Grid Name="grdPostbuild" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" IsEnabled="False" Margin="20,4,8,8">
+          <TextBox  Name="txtPostbuild" Grid.Row="1" Classes="dialogfw"/>
+          <Button Classes="dialog" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Name="btnPostbuild">...</Button>
+        </Grid>
+
+        <CheckBox Name="chkEmulator" Grid.Row="5" Grid.Column="6"  Margin="0,8,0,0">Launch external emulator</CheckBox>
+        <Grid Name="grdEmulator" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" IsEnabled="False" Margin="20,4,8,8">
+          <TextBox  Name="txtEmulator" Grid.Row="1" Classes="dialogfw"/>
+          <Button Classes="dialog" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Name="btnEmulator">...</Button>
+        </Grid>
+
+      </StackPanel>
+    </Grid>
+
+    <StackPanel Grid.Row="2" Grid.ColumnSpan="3" Margin="10,15,10,15" Orientation="Horizontal" HorizontalAlignment="Right">
       <Button Classes="dialog" VerticalAlignment="Bottom" Padding="7" Name="btnCancel">Cancel</Button>
       <Button Classes="dialog" VerticalAlignment="Bottom" Padding="7" Name="btnAccept">Accept</Button>
     </StackPanel>
+
   </Grid>
 </wnd:ZXWindowBase>

--- a/ZXBStudio/Dialogs/ZXBuildSettingsDialog.axaml
+++ b/ZXBStudio/Dialogs/ZXBuildSettingsDialog.axaml
@@ -93,12 +93,14 @@
           <Button Classes="dialog" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Name="btnPostbuild">...</Button>
         </Grid>
 
-        <CheckBox Name="chkEmulator" Grid.Row="5" Grid.Column="6"  Margin="0,8,0,0">Launch external emulator</CheckBox>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+          <CheckBox Name="chkEmulator" Grid.Row="5" Grid.Column="6"  Margin="0,8,4,0">Launch external emulator (program or bash to launch)</CheckBox>
+          <svg:Svg Path="/Svg/White/circle-info-solid.svg" Width="16" ToolTip.Tip="Parameters: %1=project path, %2=compiled file without extension"></svg:Svg>
+        </StackPanel>
         <Grid Name="grdEmulator" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto" IsEnabled="False" Margin="20,4,8,8">
           <TextBox  Name="txtEmulator" Grid.Row="1" Classes="dialogfw"/>
           <Button Classes="dialog" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" Name="btnEmulator">...</Button>
         </Grid>
-
       </StackPanel>
     </Grid>
 

--- a/ZXBStudio/Dialogs/ZXBuildSettingsDialog.axaml.cs
+++ b/ZXBStudio/Dialogs/ZXBuildSettingsDialog.axaml.cs
@@ -120,20 +120,20 @@ namespace ZXBasicStudio.Dialogs
         private async void BtnEmulator_Tapped(object? sender, Avalonia.Input.TappedEventArgs e)
         {
             var fileTypes = new FilePickerFileType[3];
-            fileTypes[0] = new FilePickerFileType("Executable files (*.exe)") { Patterns = new[] { "*.exe" } };
-            fileTypes[1] = new FilePickerFileType("Batch/Shell files (*.bat, *.sh)") { Patterns = new[] { "*.bat", "*.sh" } };
+            fileTypes[0] = new FilePickerFileType("Batch/Shell files (*.bat, *.sh)") { Patterns = new[] { "*.bat", "*.sh" } };
+            fileTypes[1] = new FilePickerFileType("Executable files (*.exe)") { Patterns = new[] { "*.exe" } };
             fileTypes[2] = new FilePickerFileType("All files (*.*)") { Patterns = new[] { "*", "*.*" } };
 
-            var select = await StorageProvider.SaveFilePickerAsync(new Avalonia.Platform.Storage.FilePickerSaveOptions
+            var select = await StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
             {
-                ShowOverwritePrompt = true,
-                FileTypeChoices = fileTypes,
-                Title = "Select prebuild file...",
+                FileTypeFilter = fileTypes.ToArray(),
+                Title = "Select emulator launcher file...",
             });
 
-            if (select != null)
+            if (select != null && select.Count() != 0)
             {
-                txtEmulator.Text = Path.GetFullPath(select.Path.LocalPath);
+                var fileName = Path.GetFullPath(select[0].Path.LocalPath);
+                txtEmulator.Text = fileName;
             }
         }
 
@@ -219,14 +219,7 @@ namespace ZXBasicStudio.Dialogs
                 chkPostbuild.IsChecked = _settings.PostBuild;
                 txtPostbuild.Text = _settings.PostBuildValue.ToStringNoNull();
                 chkEmulator.IsChecked = _settings.ExternalEmulator;
-                if (_settings.ExternalEmulator)
-                {
-                    txtEmulator.Text = _settings.ExternalEmuladorValue.ToStringNoNull();
-                }
-                else
-                {
-                    txtEmulator.Text = "Use the emulator with integrated debugger";
-                }
+                txtEmulator.Text = _settings.ExternalEmuladorValue.ToStringNoNull();
             }
             else
             {
@@ -252,7 +245,7 @@ namespace ZXBasicStudio.Dialogs
                 chkPostbuild.IsChecked = false;
                 txtPostbuild.Text = "";
                 chkEmulator.IsChecked = false;
-                txtEmulator.Text = "Use the emulator with integrated debugger";
+                txtEmulator.Text = "";
             }
             UpdateCustomBuilder();
         }

--- a/ZXBStudio/Dialogs/ZXBuildSettingsDialog.axaml.cs
+++ b/ZXBStudio/Dialogs/ZXBuildSettingsDialog.axaml.cs
@@ -2,6 +2,9 @@ using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using ZXBasicStudio.Classes;
 using System.Linq;
+using System.Text;
+using System.IO;
+using ZXBasicStudio.Common;
 
 namespace ZXBasicStudio.Dialogs
 {
@@ -9,13 +12,147 @@ namespace ZXBasicStudio.Dialogs
     {
         ZXBuildSettings _settings = new ZXBuildSettings();
         public ZXBuildSettings Settings { get { return _settings; } set { _settings = value; UpdateUI(); } }
+
+
         public ZXBuildSettingsDialog()
         {
             InitializeComponent();
             btnAccept.Click += BtnAccept_Click;
             btnCancel.Click += BtnCancel_Click;
             ckSinclair.IsCheckedChanged += CkSinclair_IsCheckedChanged;
+
+            txtFile.TextChanged += TextBox_TextChanged;
+            txtDefines.TextChanged += TextBox_TextChanged;
+            ckBreak.Click += CheckBox_Click;
+            ckCase.Click += CheckBox_Click;
+            ckExplicit.Click += CheckBox_Click;
+            ckHeaderless.Click += CheckBox_Click;
+            ckNext.Click += CheckBox_Click;
+            ckSinclair.Click += CheckBox_Click;
+            ckStrict.Click += CheckBox_Click;
+            cbArrayBase.SelectionChanged += ComboBox_SelectionChanged;
+            cbOptimization.SelectionChanged += ComboBox_SelectionChanged;
+            cbStringBase.SelectionChanged += ComboBox_SelectionChanged;
+
+            nudOrg.ValueChanged += NumericUpDown_ValueChanged;
+            nudHeap.ValueChanged += NumericUpDown_ValueChanged;
+
+            chkPrebuild.Click += ChkPrebuild_Click;
+            chkCompiler.Click += ChkCompiler_Click;
+            chkPostbuild.Click += ChkPostbuild_Click;
+            chkEmulator.Click += ChkEmulator_Click;
+
+            btnPrebuild.Tapped += BtnPrebuild_Tapped;
+            btnPostbuild.Tapped += BtnPostbuild_Tapped;
+            btnEmulator.Tapped += BtnEmulator_Tapped;
         }
+
+        private void NumericUpDown_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e)
+        {
+            UpdateCustomBuilder();
+        }
+
+        private void ChkPrebuild_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            UpdateCustomBuilder();
+        }
+
+
+        private void ChkCompiler_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            UpdateCustomBuilder();
+        }
+
+
+        private void ChkPostbuild_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            UpdateCustomBuilder();
+        }
+
+
+        private void ChkEmulator_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            UpdateCustomBuilder();
+        }
+
+
+        private async void BtnPrebuild_Tapped(object? sender, Avalonia.Input.TappedEventArgs e)
+        {
+            var fileTypes = new FilePickerFileType[3];
+            fileTypes[0] = new FilePickerFileType("Batch/Shell files (*.bat, *.sh)") { Patterns = new[] { "*.bat", "*.sh" } };
+            fileTypes[1] = new FilePickerFileType("All files (*.*)") { Patterns = new[] { "*", "*.*" } };
+            fileTypes[2] = new FilePickerFileType("Executable files (*.exe)") { Patterns = new[] { "*.exe" } };
+
+            var select = await StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+            {
+                FileTypeFilter = fileTypes.ToArray(),
+                Title = "Select pre-build file...",
+            });
+
+            if (select != null && select.Count() != 0)
+            {
+                var fileName = Path.GetFullPath(select[0].Path.LocalPath);
+                txtPreBuild.Text = fileName;
+            }
+        }
+
+
+        private async void BtnPostbuild_Tapped(object? sender, Avalonia.Input.TappedEventArgs e)
+        {
+            var fileTypes = new FilePickerFileType[3];
+            fileTypes[0] = new FilePickerFileType("Batch/Shell files (*.bat, *.sh)") { Patterns = new[] { "*.bat", "*.sh" } };
+            fileTypes[1] = new FilePickerFileType("Executable files (*.exe)") { Patterns = new[] { "*.exe" } };
+            fileTypes[2] = new FilePickerFileType("All files (*.*)") { Patterns = new[] { "*", "*.*" } };
+
+            var select = await StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions
+            {
+                FileTypeFilter = fileTypes.ToArray(),
+                Title = "Select post-build file...",
+            });
+
+            if (select != null && select.Count() != 0)
+            {
+                var fileName = Path.GetFullPath(select[0].Path.LocalPath);
+                txtPostbuild.Text = fileName;
+            }
+        }
+
+        private async void BtnEmulator_Tapped(object? sender, Avalonia.Input.TappedEventArgs e)
+        {
+            var fileTypes = new FilePickerFileType[3];
+            fileTypes[0] = new FilePickerFileType("Executable files (*.exe)") { Patterns = new[] { "*.exe" } };
+            fileTypes[1] = new FilePickerFileType("Batch/Shell files (*.bat, *.sh)") { Patterns = new[] { "*.bat", "*.sh" } };
+            fileTypes[2] = new FilePickerFileType("All files (*.*)") { Patterns = new[] { "*", "*.*" } };
+
+            var select = await StorageProvider.SaveFilePickerAsync(new Avalonia.Platform.Storage.FilePickerSaveOptions
+            {
+                ShowOverwritePrompt = true,
+                FileTypeChoices = fileTypes,
+                Title = "Select prebuild file...",
+            });
+
+            if (select != null)
+            {
+                txtEmulator.Text = Path.GetFullPath(select.Path.LocalPath);
+            }
+        }
+
+        private void ComboBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            UpdateCustomBuilder();
+        }
+
+        private void CheckBox_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            UpdateCustomBuilder();
+        }
+
+
+        private void TextBox_TextChanged(object? sender, TextChangedEventArgs e)
+        {
+            UpdateCustomBuilder();
+        }
+
 
         private void CkSinclair_IsCheckedChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
@@ -23,22 +160,21 @@ namespace ZXBasicStudio.Dialogs
             {
                 cbArrayBase.IsEnabled = false;
                 cbStringBase.IsEnabled = false;
-                ckStrictBool.IsEnabled = false;
                 ckCase.IsEnabled = false;
 
                 cbArrayBase.SelectedIndex = 1;
                 cbStringBase.SelectedIndex = 1;
-                ckStrictBool.IsChecked = true;
                 ckCase.IsChecked = true;
             }
             else
             {
                 cbArrayBase.IsEnabled = true;
                 cbStringBase.IsEnabled = true;
-                ckStrictBool.IsEnabled = true;
                 ckCase.IsEnabled = true;
             }
+            UpdateCustomBuilder();
         }
+
 
         private void BtnCancel_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
@@ -51,7 +187,8 @@ namespace ZXBasicStudio.Dialogs
             this.Close(true);
         }
 
-        void UpdateUI()
+
+        private void UpdateUI()
         {
             if (_settings != null)
             {
@@ -64,7 +201,6 @@ namespace ZXBasicStudio.Dialogs
                 {
                     cbArrayBase.SelectedIndex = _settings.ArrayBase ?? -1;
                     cbStringBase.SelectedIndex = _settings.StringBase ?? -1;
-                    ckStrictBool.IsChecked = _settings.StrictBool;
                     ckCase.IsChecked = _settings.IgnoreCase;
                 }
 
@@ -72,20 +208,35 @@ namespace ZXBasicStudio.Dialogs
                 ckBreak.IsChecked = _settings.EnableBreak;
                 ckExplicit.IsChecked = _settings.Explicit;
                 txtDefines.Text = _settings.Defines == null || _settings.Defines.Length == 0 ? "" : string.Join(", ", _settings.Defines);
-                ckStrict.IsChecked = _settings.StrictBool;
+                ckStrict.IsChecked = _settings.Strict;
                 ckHeaderless.IsChecked = _settings.Headerless;
                 ckNext.IsChecked = _settings.NextMode;
+
+                chkPrebuild.IsChecked = _settings.PreBuild;
+                txtPreBuild.Text = _settings.PreBuildValue.ToStringNoNull();
+                chkCompiler.IsChecked = _settings.CustomCompiler;
+                txtCompiler.Text = _settings.CustomCompilerValue.ToStringNoNull();
+                chkPostbuild.IsChecked = _settings.PostBuild;
+                txtPostbuild.Text = _settings.PostBuildValue.ToStringNoNull();
+                chkEmulator.IsChecked = _settings.ExternalEmulator;
+                if (_settings.ExternalEmulator)
+                {
+                    txtEmulator.Text = _settings.ExternalEmuladorValue.ToStringNoNull();
+                }
+                else
+                {
+                    txtEmulator.Text = "Use the emulator with integrated debugger";
+                }
             }
             else
             {
                 txtFile.Text = "";
-                cbOptimization.SelectedIndex =  -1;
+                cbOptimization.SelectedIndex = -1;
                 nudOrg.Value = 32768;
                 cbArrayBase.SelectedIndex = -1;
                 cbStringBase.SelectedIndex = -1;
                 ckSinclair.IsChecked = false;
                 nudHeap.Value = 4768;
-                ckStrictBool.IsChecked = false;
                 ckBreak.IsChecked = false;
                 ckExplicit.IsChecked = false;
                 txtDefines.Text = "";
@@ -93,10 +244,21 @@ namespace ZXBasicStudio.Dialogs
                 ckStrict.IsChecked = false;
                 ckHeaderless.IsChecked = false;
                 ckNext.IsChecked = false;
+
+                chkPrebuild.IsChecked = false;
+                txtPreBuild.Text = "";
+                chkCompiler.IsChecked = false;
+                txtPreBuild.Text = "";
+                chkPostbuild.IsChecked = false;
+                txtPostbuild.Text = "";
+                chkEmulator.IsChecked = false;
+                txtEmulator.Text = "Use the emulator with integrated debugger";
             }
+            UpdateCustomBuilder();
         }
 
-        void UpdateSettings()
+
+        private void UpdateSettings()
         {
             if (_settings == null)
                 _settings = new ZXBuildSettings();
@@ -108,14 +270,88 @@ namespace ZXBasicStudio.Dialogs
             _settings.StringBase = cbStringBase.SelectedIndex == -1 ? null : cbStringBase.SelectedIndex;
             _settings.SinclairMode = ckSinclair.IsChecked ?? false;
             _settings.HeapSize = (int?)(nudHeap.Value == 4768 ? null : nudHeap.Value);
-            _settings.StrictBool = ckStrictBool.IsChecked ?? false;
             _settings.EnableBreak = ckBreak.IsChecked ?? false;
             _settings.Explicit = ckExplicit.IsChecked ?? false;
             _settings.Defines = string.IsNullOrWhiteSpace(txtDefines.Text) ? null : txtDefines.Text.Split(",").Select(s => s.Trim()).ToArray();
             _settings.IgnoreCase = ckCase.IsChecked ?? false;
-            _settings.StrictBool = ckStrict.IsChecked ?? false;
+            _settings.Strict = ckStrict.IsChecked ?? false;
             _settings.Headerless = ckHeaderless.IsChecked ?? false;
             _settings.NextMode = ckNext.IsChecked ?? false;
+
+            _settings.PreBuild = chkPrebuild.IsChecked == true;
+            _settings.PreBuildValue = txtPreBuild.Text.ToStringNoNull();
+            _settings.CustomCompiler = chkCompiler.IsChecked == true;
+            _settings.CustomCompilerValue = txtCompiler.Text.ToStringNoNull();
+            _settings.PostBuild = chkPostbuild.IsChecked == true;
+            _settings.PostBuildValue = txtPostbuild.Text.ToStringNoNull();
+            _settings.ExternalEmulator = chkEmulator.IsChecked == true;
+            _settings.ExternalEmuladorValue = txtEmulator.Text.ToStringNoNull();
+        }
+
+
+        private void UpdateCustomBuilder()
+        {
+            grdPrebuild.IsEnabled = chkPrebuild.IsChecked == true;
+            grdCompiler.IsEnabled = chkCompiler.IsChecked == true;
+            grdPostbuild.IsEnabled = chkPostbuild.IsChecked == true;
+            grdEmulator.IsEnabled = chkEmulator.IsChecked == true;
+
+            if (chkCompiler.IsChecked == true)
+            {
+                return;
+            }
+
+            var sb = new StringBuilder();
+            //sb.Append($"zxbc {txtFile.Text}");
+            sb.Append($" -O {cbOptimization.SelectedIndex}");
+            sb.Append($" -S {nudOrg.Text}");
+            if (cbArrayBase.SelectedIndex == 1)
+            {
+                sb.Append(" --array-base 1");
+            }
+            if (cbStringBase.SelectedIndex == 1)
+            {
+                sb.Append(" --string-base 1");
+            }
+            sb.Append($" -H {nudHeap.Text}");
+            if (ckSinclair.IsChecked == true)
+            {
+                sb.Append(" -Z");
+            }
+            if (ckBreak.IsChecked == true)
+            {
+                sb.Append(" --enable-break");
+            }
+            if (ckExplicit.IsChecked == true)
+            {
+                sb.Append(" --explicit");
+            }
+            if (ckCase.IsChecked == true)
+            {
+                sb.Append(" -i");
+            }
+            if (ckStrict.IsChecked == true)
+            {
+                sb.Append(" --strict");
+            }
+            if (ckHeaderless.IsChecked == true)
+            {
+                sb.Append(" --headerless");
+            }
+            if (ckNext.IsChecked == true)
+            {
+                sb.Append(" --zxnext --arch=zxnext");
+            }
+            if (!string.IsNullOrEmpty(txtDefines.Text))
+            {
+                var defines = txtDefines.Text.Split(",").Select(s => s.Trim()).ToArray();
+                foreach (var define in defines)
+                {
+                    sb.Append($" -D {define}");
+                }
+            }
+
+            txtCompiler.Text = sb.ToString().Trim();
         }
     }
 }

--- a/ZXBStudio/Dialogs/ZXOptionsDialog.axaml
+++ b/ZXBStudio/Dialogs/ZXOptionsDialog.axaml
@@ -12,10 +12,10 @@
         Title="General options" WindowStartupLocation="CenterOwner">
   <Grid ColumnDefinitions="*,7*,8*,2*,*" RowDefinitions="*,*,*,*,*,*,*,*,*,1.5*,1.5*,1.5*">
     <TextBlock Classes="dialog" Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" >ZXBC path:</TextBlock>
-    <TextBox Classes="dialog" Grid.Row="0" Grid.Column="2" Name="txtZxbc" IsReadOnly="True"></TextBox>
+    <TextBox Classes="dialog" Grid.Row="0" Grid.Column="2" Name="txtZxbc" IsReadOnly="False"></TextBox>
     <Button Classes="dialog" Grid.Row="0" Grid.Column="3" VerticalAlignment="Center" Name="btnSelectZxbc">...</Button>
     <TextBlock Classes="dialog" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center" >ZXBASM path:</TextBlock>
-    <TextBox Classes="dialog" Grid.Row="1" Grid.Column="2" Name="txtZxbasm" IsReadOnly="True"></TextBox>
+    <TextBox Classes="dialog" Grid.Row="1" Grid.Column="2" Name="txtZxbasm" IsReadOnly="False"></TextBox>
     <Button Classes="dialog" Grid.Row="1" Grid.Column="3" VerticalAlignment="Center" Name="btnSelectZxbasm">...</Button>
     <TextBlock Classes="dialog" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center">Editor font size:</TextBlock>
     <Border Height="32" Grid.Row="2" Grid.Column="2" BorderBrush="#ff909090" BorderThickness="2" CornerRadius="5" Padding="-1" Margin="5,0,5,0">
@@ -35,7 +35,7 @@
     <CheckBox Classes="dialog" Name="ckAntiAlias" Grid.Column="2" Grid.Row="7"></CheckBox>
 
     <TextBlock Classes="dialog" Grid.Row="8" Grid.Column="1" VerticalAlignment="Center">Next emulator path:</TextBlock>
-    <TextBox Classes="dialog" Grid.Row="8" Grid.Column="2" Name="txtNextEmulator" IsReadOnly="True"></TextBox>
+    <TextBox Classes="dialog" Grid.Row="8" Grid.Column="2" Name="txtNextEmulator" IsReadOnly="False"></TextBox>
     <Button Classes="dialog" Grid.Row="8" Grid.Column="3" VerticalAlignment="Center" Name="btnSelectNextEmulator">...</Button>
 
     <TextBlock Classes="dialog" Grid.Row="9" Grid.Column="1" VerticalAlignment="Center">Disable autocomplete:</TextBlock>


### PR DESCRIPTION
V1.6.0 - beta 4
- Build Options (Project -> Configure project)
  - Removed "Strict Bool" options that was deprecated on v1.18.0 of the compiler
  - "Strict" and “Header less” options were not being applied when compiling.
  - Added 4 advanced actions:
    - Enable pre-build: Launch a program or bash (.bat / .sh) before compiling
    - Custom compiler parameters: Allows the compilation parameters to be set manually
    - Enable post-build: Launch a program or bash (.bat / .sh) before compiling
    - Launch external emulator: Launches its own program or bash (.bat / .sh) after post-build instead of the embedded emulator
- Output log window: Ahora se puede seleccionar y copiar texto.

